### PR TITLE
Fix uploading files

### DIFF
--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -4,7 +4,6 @@ import com.ioki.lokalise.gradle.plugin.LokaliseExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileTree
-import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
@@ -33,7 +32,7 @@ internal abstract class UploadTranslationsTask : DefaultTask() {
             throw GradleException("Please set 'lokalise.projectId' and 'lokalise.apiToken'")
 
         val fileTree = translationFilesToUpload.get()
-        val stringFilesAsString = fileTree.toList().joinToString {
+        val stringFilesAsString = fileTree.toList().joinToString(separator = ",") {
             it.path.replace(fileTree.dir.absolutePath, ".")
         }
         project.exec {

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseGradlePluginTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseGradlePluginTest.kt
@@ -29,7 +29,8 @@ class LokaliseGradlePluginTest {
             }
             val filesToUpload = provider {
                 fileTree(rootDir) {
-                    include("**gradle**")
+                    include("build.gradle.kts")
+                    include("settings.gradle")
                 }
             }
             lokalise {
@@ -116,7 +117,12 @@ class LokaliseGradlePluginTest {
             .withArguments("uploadTranslations", "--info")
             .buildAndFail()
 
-        expectThat(result.output).contains("./build.gradle.kts,./settings.gradle")
+        val expectBuildAndSettingOrSettingAndBuild = Regex(
+            "\\./build\\.gradle\\.kts,\\./settings\\.gradle" +
+                    "|" +
+                    "\\./settings\\.gradle,\\./build\\.gradle\\.kts"
+        )
+        expectThat(result.output).contains(expectBuildAndSettingOrSettingAndBuild)
         expectThat(result.output).contains("400 Invalid `X-Api-Token`")
     }
 }


### PR DESCRIPTION
Unfourtnaly, the default separator is `, ` (space included).
This doesn't work with the CLI.
We have to use a string without a space included. 
