### PR TITLE
Download correct binary for Intel based MacOS

### DIFF
--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadLokaliseCliTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadLokaliseCliTask.kt
@@ -54,8 +54,11 @@ internal fun TaskContainer.registerDownloadLokaliseCliTask(): TaskProvider<Downl
         it.lokaliseCliFile.set(lokaliseBuildDir.resolve("cli"))
     }
 
-private fun findCliUrl(): String = if (System.getProperty("os.name").lowercase(Locale.getDefault()).contains("mac")) {
-    "https://github.com/lokalise/lokalise-cli-2-go/releases/download/v2.6.8/lokalise2_darwin_arm64.tar.gz"
-} else {
-    "https://github.com/lokalise/lokalise-cli-2-go/releases/download/v2.6.8/lokalise2_linux_x86_64.tar.gz"
+private fun findCliUrl(): String = when {
+    System.getProperty("os.name").lowercase(Locale.getDefault()).contains("mac") && System.getProperty("os.arch") == "x86_64" ->
+        "https://github.com/lokalise/lokalise-cli-2-go/releases/download/v2.6.8/lokalise2_darwin_x86_64.tar.gz"
+    System.getProperty("os.name").lowercase(Locale.getDefault()).contains("mac") ->
+        "https://github.com/lokalise/lokalise-cli-2-go/releases/download/v2.6.8/lokalise2_darwin_arm64.tar.gz"
+    else ->
+        "https://github.com/lokalise/lokalise-cli-2-go/releases/download/v2.6.8/lokalise2_linux_x86_64.tar.gz"
 }


### PR DESCRIPTION
While this plugin using the CLI under the hood, not all processor types are supported now. I added here the Intel Mac variant to get this plugin running on my environment.

If this project is really intended to be used publicly, we should replace the CLI with a Java library. That make the plugin generic and not platform specific.