### PR TITLE
Better performance for the upload task 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.kotlinCoroutines)
     testImplementation(libs.test.kotlinTest)
     testImplementation(libs.test.strikt)
+    testImplementation(libs.test.kotlinCoroutinesTest)
 }
 
 gradlePlugin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,14 @@
 [versions]
 kotlinVersion = "1.9.22"
+kotlinxCoroutinesVersion = "1.7.3"
 
 [libraries]
+lokaliseApi = "com.ioki:lokalise-api:0.0.2"
+kotlinCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesVersion" }
+
 test-kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlinVersion" }
 test-strikt = "io.strikt:strikt-core:0.34.1"
-lokaliseApi = "com.ioki:lokalise-api:0.0.2"
-kotlinCoroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
+test-kotlinCoroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesVersion" }
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinVersion" }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/internal/LokaliseApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/internal/LokaliseApi.kt
@@ -1,0 +1,92 @@
+package com.ioki.lokalise.gradle.plugin.internal
+
+import com.ioki.lokalise.api.Lokalise
+import com.ioki.lokalise.api.Result
+import com.ioki.lokalise.api.models.FileUpload
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import org.gradle.api.GradleException
+
+internal class LokaliseApi(
+    private val lokalise: Lokalise,
+    private val projectId: String,
+) {
+
+    private val finishedProcessStatus = listOf("cancelled", "finished", "failed")
+
+    suspend fun uploadFiles(
+        fileInfos: List<FileInfo>,
+        langIso: String,
+        params: Map<String, Any>,
+    ): List<FileUpload> = coroutineScope {
+        val chunkedToSix = fileInfos.chunkedToSix()
+        chunkedToSix.flatMapIndexed { index, chunkedFileInfos ->
+            val fileUploads = chunkedFileInfos.map { fileInfo ->
+                async {
+                    val uploadResult = lokalise.uploadFile(
+                        projectId = projectId,
+                        data = fileInfo.base64FileContent,
+                        filename = fileInfo.fileName,
+                        langIso = langIso,
+                        bodyParams = params
+                    )
+
+                    when (uploadResult) {
+                        is Result.Failure -> throw GradleException(uploadResult.error.message)
+                        is Result.Success -> uploadResult.data
+                    }
+                }
+            }
+            if (index != chunkedToSix.lastIndex) delay(1000)
+            fileUploads.awaitAll()
+        }
+    }
+
+    suspend fun checkProcess(fileUploads: List<FileUpload>) = coroutineScope {
+        val chunkedToSix = fileUploads.chunkedToSix()
+        chunkedToSix.forEachIndexed { index, chunkedFileUploads ->
+            val deferreds = chunkedFileUploads.map {
+                async {
+                    do {
+                        val process = lokalise.retrieveProcess(
+                            projectId = projectId,
+                            processId = it.process.processId
+                        )
+
+                        when (process) {
+                            is Result.Failure -> {
+                                if (process.error.code == 404) {
+                                    // 404 indicates it is done... I guess :)
+                                    break
+                                }
+                            }
+
+                            is Result.Success -> {
+                                val processStatus = process.data.process.status
+                                if (finishedProcessStatus.contains(processStatus)) {
+                                    break
+                                }
+                            }
+                        }
+                        delay(500)
+                    } while (true)
+                }
+            }
+            if (index != chunkedToSix.lastIndex) delay(1000)
+            deferreds.awaitAll()
+        }
+    }
+
+    /**
+     * This is required because Lokalise API only allows 6 files to be uploaded at once.
+     * See also [https://lokalise.com/blog/announcing-api-rate-limits/](https://lokalise.com/blog/announcing-api-rate-limits/)
+     */
+    private fun <T> List<T>.chunkedToSix(): List<List<T>> = chunked(6)
+}
+
+internal data class FileInfo(
+    val fileName: String,
+    val base64FileContent: String,
+)

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -2,6 +2,7 @@ package com.ioki.lokalise.gradle.plugin.tasks
 
 import com.ioki.lokalise.api.Lokalise
 import com.ioki.lokalise.api.Result
+import com.ioki.lokalise.api.models.FileUpload
 import com.ioki.lokalise.gradle.plugin.LokaliseExtension
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.DefaultTask
@@ -31,79 +32,82 @@ internal abstract class UploadTranslationsTask : DefaultTask() {
     @get:Input
     abstract val params: MapProperty<String, Any>
 
-    @OptIn(ExperimentalEncodingApi::class)
     @TaskAction
     fun f() {
         if (!projectId.isPresent || !apiToken.isPresent)
             throw GradleException("Please set 'lokalise.projectId' and 'lokalise.apiToken'")
 
-        val fileTree = translationFilesToUpload.get()
-        val fileInfo = fileTree.map {
-            val fileName = it.path.replace(fileTree.dir.absolutePath, ".")
-            val base64FileContent = Base64.encode(it.readBytes())
-            fileName to base64FileContent
-        }
-
-        logger.log(
-            LogLevel.INFO,
-            "Execute uploading file with the following params:\n" +
-                "${params.get()}\n" +
-                "and the following file info:\n" +
-                "$fileInfo"
-        )
-
-        val langIso = params.get()["lang_iso"]
-        val newParams = params.get().toMutableMap().apply { remove("lang_iso") }
-
         val lokalise = Lokalise(apiToken.get())
-        val fileUploads = fileInfo.map { (fileName, base64FileContent) ->
-            runBlocking {
-                val fileUploadResult = lokalise.uploadFile(
-                    projectId = projectId.get(),
-                    data = base64FileContent,
-                    filename = fileName,
-                    langIso = langIso.toString(),
-                    bodyParams = newParams
+        translationFilesToUpload.get()
+            .toFileInfo()
+            .also {
+                logger.log(
+                    LogLevel.INFO,
+                    "Execute uploading file with the following params:\n" +
+                        "${params.get()}\n" +
+                        "and the following file info:\n" +
+                        "$it"
                 )
-                when (fileUploadResult) {
-                    is Result.Failure -> throw GradleException(fileUploadResult.error.message)
-                    is Result.Success -> fileUploadResult.data
-                }
             }
+            .uploadEach(lokalise, params.get("lang_iso").toString(), params.remove("lang_iso"))
+            .checkProcess(lokalise)
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun ConfigurableFileTree.toFileInfo(): List<FileInfo> = map {
+        val fileName = it.path.replace(dir.absolutePath, ".")
+        val base64FileContent = Base64.encode(it.readBytes())
+        FileInfo(fileName, base64FileContent)
+    }
+
+    private fun List<FileInfo>.uploadEach(
+        lokalise: Lokalise,
+        langIso: String,
+        params: Map<String, Any>,
+    ): List<FileUpload> = map { fileInfo ->
+        val uploadResult = runBlocking {
+            lokalise.uploadFile(
+                projectId = projectId.get(),
+                data = fileInfo.base64FileContent,
+                filename = fileInfo.fileName,
+                langIso = langIso,
+                bodyParams = params
+            )
         }
+        when (uploadResult) {
+            is Result.Failure -> throw GradleException(uploadResult.error.message)
+            is Result.Success -> uploadResult.data
+        }
+    }
 
-        runBlocking {
-            fileUploads
-                .map { fileUpload ->
-                    do {
-                        val process = lokalise.retrieveProcess(
-                            projectId = projectId.get(),
-                            processId = fileUpload.process.processId
-                        )
-                        when (process) {
-                            is Result.Failure -> {
-                                if (process.error.code == 404) {
-                                    // 404 indicates it is done... I guess :)
-                                    break
-                                }
-                            }
-
-                            is Result.Success -> {
-                                val processStatus = process.data.process.status
-                                if (finishedProcessStatus.contains(processStatus)) {
-                                    break
-                                }
-                            }
+    private fun List<FileUpload>.checkProcess(lokalise: Lokalise) = runBlocking {
+        forEach { fileUpload ->
+            do {
+                val process = lokalise.retrieveProcess(
+                    projectId = projectId.get(),
+                    processId = fileUpload.process.processId
+                )
+                when (process) {
+                    is Result.Failure -> {
+                        if (process.error.code == 404) {
+                            // 404 indicates it is done... I guess :)
+                            break
                         }
+                    }
 
-                        Thread.sleep(1000)
-                    } while (true)
+                    is Result.Success -> {
+                        val processStatus = process.data.process.status
+                        if (finishedProcessStatus.contains(processStatus)) {
+                            break
+                        }
+                    }
                 }
+
+                Thread.sleep(1000)
+            } while (true)
         }
     }
 }
-
-private val finishedProcessStatus = listOf("cancelled", "finished", "failed")
 
 internal fun TaskContainer.registerUploadTranslationTask(
     lokaliseExtensions: LokaliseExtension,
@@ -113,3 +117,16 @@ internal fun TaskContainer.registerUploadTranslationTask(
     it.translationFilesToUpload.set(lokaliseExtensions.uploadStringsConfig.translationsFilesToUpload)
     it.params.set(lokaliseExtensions.uploadStringsConfig.params)
 }
+
+private val finishedProcessStatus = listOf("cancelled", "finished", "failed")
+
+private data class FileInfo(
+    val fileName: String,
+    val base64FileContent: String,
+)
+
+private fun MapProperty<String, Any>.get(key: String): Any =
+    get().getOrElse(key) { throw GradleException("Value for key(=$key) not found") }
+
+private fun MapProperty<String, Any>.remove(key: String): Map<String, Any> =
+    get().toMutableMap().apply { remove(key) }

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadTranslationsTaskTest.kt
@@ -36,15 +36,15 @@ class DownloadTranslationsTaskTest {
                 downloadStringsConfigs {
                     register("library") {
                         params(
-                            "--format" to "xml",
-                            "--filter-langs" to listOf("en","de","de_CH","fr_CH","es","it","nl","ca","ar"),
-                            "--export-empty-as" to "skip",
-                            "--include-description" to "false",
-                            "--export-sort" to "first_added",
-                            "--directory-prefix" to ".",
-                            "--filter-filenames" to listOf("./src/main/res/values-%LANG_ISO%/strings.xml"),
-                            "--indentation" to "4sp",
-                            "--replace-breaks" to false
+                            "format" to "xml",
+                            "filter_langs" to listOf("en","de","de_CH","fr_CH","es","it","nl","ca","ar"),
+                            "export_empty_as" to "skip",
+                            "include_description" to "false",
+                            "export_sort" to "first_added",
+                            "directory_prefix" to ".",
+                            "filter_filenames" to listOf("./src/main/res/values-%LANG_ISO%/strings.xml"),
+                            "indentation" to "4sp",
+                            "replace_breaks" to false
                         )   
                     }
                 }

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseApiTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseApiTest.kt
@@ -1,0 +1,339 @@
+package com.ioki.lokalise.gradle.plugin.unit
+
+import com.ioki.lokalise.api.Lokalise
+import com.ioki.lokalise.api.Result
+import com.ioki.lokalise.api.models.FileDownload
+import com.ioki.lokalise.api.models.FileUpload
+import com.ioki.lokalise.api.models.Projects
+import com.ioki.lokalise.api.models.RetrievedProcess
+import com.ioki.lokalise.gradle.plugin.internal.FileInfo
+import com.ioki.lokalise.gradle.plugin.internal.LokaliseApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LokaliseApiTest {
+
+    @Test
+    fun `concurrency uploadFile with 1-6 files does not delay and is done after 0 millis`() = runTest {
+        val lokalise = createLokalise()
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        (0..6).forEach {
+            expectThat(currentTime).isEqualTo(0)
+            lokaliseApi.uploadFiles(
+                fileInfos = mutableListOf<FileInfo>().apply {
+                    repeat(it) { add(createFileInfo()) }
+                },
+                langIso = "langIso",
+                params = mapOf(),
+            )
+            expectThat(currentTime).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `concurrency uploadFile with 7-12 files delay once and is done after 1000 millis`() = runTest {
+        val lokalise = createLokalise()
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        var expectedTime = 0L
+        (7..12).forEach {
+            expectThat(currentTime).isEqualTo(expectedTime)
+            lokaliseApi.uploadFiles(
+                fileInfos = mutableListOf<FileInfo>().apply {
+                    repeat(it) { add(createFileInfo()) }
+                },
+                langIso = "langIso",
+                params = mapOf(),
+            )
+            expectedTime += 1000
+            expectThat(currentTime).isEqualTo(expectedTime)
+        }
+    }
+
+    @Test
+    fun `concurrency uploadFile with 13-18 files delay twice and is done after 2000 millis`() = runTest {
+        val lokalise = createLokalise()
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        var expectedTime = 0L
+        (13..18).forEach {
+            expectThat(currentTime).isEqualTo(expectedTime)
+            lokaliseApi.uploadFiles(
+                fileInfos = mutableListOf<FileInfo>().apply {
+                    repeat(it) { add(createFileInfo()) }
+                },
+                langIso = "langIso",
+                params = mapOf(),
+            )
+            expectedTime += 2000
+            expectThat(currentTime).isEqualTo(expectedTime)
+        }
+    }
+
+    @Test
+    fun `concurrency uploadFile with 5 files and 1200 delay in upload should wait for upload only`() = runTest {
+        val lokalise = createLokalise(
+            uploadFileResult = {
+                delay(1200)
+                Result.Success(createFileUpload())
+            }
+        )
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        expectThat(currentTime).isEqualTo(0L)
+        lokaliseApi.uploadFiles(
+            fileInfos = mutableListOf<FileInfo>().apply {
+                repeat(5) { add(createFileInfo()) }
+            },
+            langIso = "langIso",
+            params = mapOf(),
+        )
+        expectThat(currentTime).isEqualTo(1200)
+    }
+
+    @Test
+    fun `concurrency uploadFile with 7 files and 700 delay in upload should wait for delay of files plus last upload`() =
+        runTest {
+            val lokalise = createLokalise(
+                uploadFileResult = {
+                    delay(700)
+                    Result.Success(createFileUpload())
+                }
+            )
+            val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+            expectThat(currentTime).isEqualTo(0L)
+            lokaliseApi.uploadFiles(
+                fileInfos = mutableListOf<FileInfo>().apply {
+                    repeat(7) { add(createFileInfo()) }
+                },
+                langIso = "langIso",
+                params = mapOf(),
+            )
+            expectThat(currentTime).isEqualTo(1700)
+        }
+
+    @Test
+    fun `concurrency checkProcess with 1-6 files does not delay and is done after 0 millis`() = runTest {
+        val lokalise = createLokalise()
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        (0..6).forEach {
+            expectThat(currentTime).isEqualTo(0)
+            lokaliseApi.checkProcess(
+                fileUploads = mutableListOf<FileUpload>().apply {
+                    repeat(it) { add(createFileUpload()) }
+                },
+            )
+            expectThat(currentTime).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `concurrency checkProcess with 7-12 files delay once and is done after 1000 millis`() = runTest {
+        val lokalise = createLokalise()
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        var expectedTime = 0L
+        (7..12).forEach {
+            expectThat(currentTime).isEqualTo(expectedTime)
+            lokaliseApi.checkProcess(
+                fileUploads = mutableListOf<FileUpload>().apply {
+                    repeat(it) { add(createFileUpload()) }
+                },
+            )
+            expectedTime += 1000
+            expectThat(currentTime).isEqualTo(expectedTime)
+        }
+    }
+
+    @Test
+    fun `concurrency checkProcess with 13-18 files delay twice and is done after 2000 millis`() = runTest {
+        val lokalise = createLokalise()
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        var expectedTime = 0L
+        (13..18).forEach {
+            expectThat(currentTime).isEqualTo(expectedTime)
+            lokaliseApi.checkProcess(
+                fileUploads = mutableListOf<FileUpload>().apply {
+                    repeat(it) { add(createFileUpload()) }
+                },
+            )
+            expectedTime += 2000
+            expectThat(currentTime).isEqualTo(expectedTime)
+        }
+    }
+
+    @Test
+    fun `concurrency checkProcess with 5 files and 1200 delay in upload should wait for upload only`() = runTest {
+        val lokalise = createLokalise(
+            retrieveProcessResult = {
+                delay(1200)
+                Result.Success(createRetrieveProcess(status = "finished"))
+            }
+        )
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        expectThat(currentTime).isEqualTo(0L)
+        lokaliseApi.checkProcess(
+            fileUploads = mutableListOf<FileUpload>().apply {
+                repeat(5) { add(createFileUpload()) }
+            },
+        )
+        expectThat(currentTime).isEqualTo(1200)
+    }
+
+    @Test
+    fun `concurrency checkProcess with 7 files and 700 delay in upload should wait for delay of files plus last upload`() =
+        runTest {
+            val lokalise = createLokalise(
+                retrieveProcessResult = {
+                    delay(700)
+                    Result.Success(createRetrieveProcess(status = "finished"))
+                }
+            )
+            val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+            expectThat(currentTime).isEqualTo(0L)
+            lokaliseApi.checkProcess(
+                fileUploads = mutableListOf<FileUpload>().apply {
+                    repeat(7) { add(createFileUpload()) }
+                },
+            )
+            expectThat(currentTime).isEqualTo(1700)
+        }
+
+    @Test
+    fun `concurrency checkProcess with 1 file should delay inside while for 1500`() = runTest {
+        var timesCheckProcess = 0
+        val lokalise = createLokalise(
+            retrieveProcessResult = {
+                timesCheckProcess += 1
+                val status = if (timesCheckProcess > 3) "finished" else "notFinished"
+                Result.Success(createRetrieveProcess(status = status))
+            }
+        )
+        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+
+        expectThat(currentTime).isEqualTo(0L)
+        lokaliseApi.checkProcess(
+            fileUploads = mutableListOf<FileUpload>().apply {
+                repeat(1) { add(createFileUpload()) }
+            },
+        )
+        expectThat(currentTime).isEqualTo(1500)
+    }
+}
+
+private fun createFileUpload(
+    projectId: String = "",
+    processId: String = "",
+    status: String = "",
+    type: String = "",
+    message: String = "",
+    createdBy: Int = 0,
+    createdByEmail: String = "",
+    createdAt: String = "",
+    createdAtTimestamp: Int = 0
+): FileUpload = FileUpload(
+    projectId = projectId,
+    process = FileUpload.Process(
+        processId = processId,
+        status = status,
+        type = type,
+        message = message,
+        createdBy = createdBy,
+        createdByEmail = createdByEmail,
+        createdAt = createdAt,
+        createdAtTimestamp = createdAtTimestamp
+    )
+)
+
+private fun createFileInfo(
+    fileName: String = "",
+    base64FileContent: String = ""
+): FileInfo = FileInfo(
+    fileName = fileName,
+    base64FileContent = base64FileContent
+)
+
+private fun createRetrieveProcess(
+    projectId: String = "",
+    processId: String = "",
+    status: String = "",
+    type: String = "",
+    message: String = "",
+    createdBy: Int = 0,
+    createdByEmail: String = "",
+    createdAt: String = "",
+    createdAtTimestamp: Int = 0
+): RetrievedProcess = RetrievedProcess(
+    projectId = projectId,
+    process = RetrievedProcess.Process(
+        processId = processId,
+        status = status,
+        type = type,
+        message = message,
+        createdBy = createdBy,
+        createdByEmail = createdByEmail,
+        createdAt = createdAt,
+        createdAtTimestamp = createdAtTimestamp,
+        details = RetrievedProcess.Process.Details(
+            emptyList()
+        )
+    )
+)
+
+private fun createLokalise(
+    uploadFileResult: suspend () -> Result<FileUpload> = { Result.Success(createFileUpload()) },
+    retrieveProcessResult: suspend () -> Result<RetrievedProcess> = { Result.Success(createRetrieveProcess(status = "finished")) }
+): Lokalise = object : FakeLokalise() {
+    override suspend fun uploadFile(
+        projectId: String,
+        data: String,
+        filename: String,
+        langIso: String,
+        bodyParams: Map<String, Any>
+    ): Result<FileUpload> = uploadFileResult()
+
+    override suspend fun retrieveProcess(
+        projectId: String,
+        processId: String
+    ): Result<RetrievedProcess> = retrieveProcessResult()
+}
+
+private open class FakeLokalise : Lokalise {
+    override suspend fun allProjects(queryParams: Map<String, Any>): Result<Projects> {
+        error("Not overriden")
+    }
+
+    override suspend fun downloadFiles(
+        projectId: String,
+        format: String,
+        bodyParams: Map<String, Any>
+    ): Result<FileDownload> {
+        error("Not overriden")
+    }
+
+    override suspend fun retrieveProcess(projectId: String, processId: String): Result<RetrievedProcess> {
+        error("Not overriden")
+    }
+
+    override suspend fun uploadFile(
+        projectId: String,
+        data: String,
+        filename: String,
+        langIso: String,
+        bodyParams: Map<String, Any>
+    ): Result<FileUpload> {
+        error("Not overriden")
+    }
+}

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -41,10 +41,10 @@ class UploadTranslationsTaskTest {
                 uploadStringsConfig {
                     translationsFilesToUpload.set(filesToUpload)
                     params(
-                        "--replace-modified" to true,
-                        "--cleanup-mode" to true,
-                        "--distinguish-by-file" to true,
-                        "--lang-iso" to "en_BZ",
+                        "replace_modified" to true,
+                        "cleanup_mode" to true,
+                        "distinguish_by_file" to true,
+                        "lang_iso" to "en_BZ",
                     )
                 }
             }
@@ -85,8 +85,8 @@ class UploadTranslationsTaskTest {
             .withArguments("uploadTranslations", "--info")
             .buildAndFail()
 
-        expectThat(result.output).contains("--replace-modified=true")
-        expectThat(result.output).contains("--cleanup-mode=true")
+        expectThat(result.output).contains("replace_modified=true")
+        expectThat(result.output).contains("cleanup_mode=true")
         expectThat(result.output).contains("Invalid `X-Api-Token`")
     }
 


### PR DESCRIPTION
This is a bit of a rewrite for the UploadTranslationsTasks 😅 
What we did before:
* We uploaded each file, one by one, in `runBlocking`.
* Upload.. wait until its done... Upload... wait until its done... Upload .. repeat
* After each file were uploaded, we checked the upload status.. For each file (same process as with the uploadig part)

Now we do it differently.. more concurrect.
1. We pack each upload files into a chunk of 6 (because of rate limit on lokalise API)
2. We upload these 6 files in parallel
3. We wait a second and upload the next 6 files... until there is no chunk left
4. After each file uploaded, we do the same but with the upload status process. We chunk in 6 and check parallel 6 times if each file were processed. 

This might (hopefully 😁 ) improve the upload process a bit because we run 6 files in parallel instead of step by step.