### PR TITLE
61 Make `poll` optional in upload

### DIFF
--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
@@ -1,4 +1,4 @@
-package com.ioki.lokalise.gradle.plugin.internal
+package com.ioki.lokalise.gradle.plugin
 
 import com.ioki.lokalise.api.Lokalise
 import com.ioki.lokalise.api.Result

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseExtension.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseExtension.kt
@@ -19,7 +19,7 @@ abstract class LokaliseExtension(
 
     val projectId: Property<String> = objects.property(String::class.java)
 
-    val pollUploadProcess: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+    val pollUploadProcess: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
     internal val downloadStringsConfigs: NamedDomainObjectContainer<DownloadStringsConfig> =
         objects.domainObjectContainer(DownloadStringsConfig::class.java)

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseExtension.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseExtension.kt
@@ -19,6 +19,8 @@ abstract class LokaliseExtension(
 
     val projectId: Property<String> = objects.property(String::class.java)
 
+    val pollUploadProcess: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
     internal val downloadStringsConfigs: NamedDomainObjectContainer<DownloadStringsConfig> =
         objects.domainObjectContainer(DownloadStringsConfig::class.java)
 

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -10,23 +10,24 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 
 class LokaliseGradlePlugin : Plugin<Project> {
-    override fun apply(target: Project) {
-        val lokaliseExtensions = target.extensions.createLokaliseExtension()
+    override fun apply(project: Project) {
+        val lokaliseExtensions = project.extensions.createLokaliseExtension()
 
-        val lokaliseApi: Provider<LokaliseApi> = lokaliseExtensions.apiToken.zip(
+        val lokaliseApi: Provider<LokaliseApi> = project.providers.zip(
+            lokaliseExtensions.apiToken,
             lokaliseExtensions.projectId
         ) { token, id ->
             DefaultLokaliseApi(Lokalise(token), id)
         }
 
-        target.tasks.registerUploadTranslationTask(
+        project.tasks.registerUploadTranslationTask(
             lokaliseApi = lokaliseApi,
             lokaliseExtensions = lokaliseExtensions,
         )
 
-        val downloadTranslationsForAll = target.tasks.register("downloadTranslationsForAll")
+        val downloadTranslationsForAll = project.tasks.register("downloadTranslationsForAll")
         lokaliseExtensions.downloadStringsConfigs.all {
-            val customDownloadTask = target.tasks.registerDownloadTranslationTask(
+            val customDownloadTask = project.tasks.registerDownloadTranslationTask(
                 config = it,
                 lokaliseExtensions = lokaliseExtensions,
             )

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -1,6 +1,5 @@
 package com.ioki.lokalise.gradle.plugin
 
-import com.ioki.lokalise.gradle.plugin.internal.LokaliseApiFactory
 import com.ioki.lokalise.gradle.plugin.tasks.registerDownloadTranslationTask
 import com.ioki.lokalise.gradle.plugin.tasks.registerUploadTranslationTask
 import org.gradle.api.Plugin

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -1,5 +1,6 @@
 package com.ioki.lokalise.gradle.plugin
 
+import com.ioki.lokalise.gradle.plugin.internal.LokaliseApiBuildService
 import com.ioki.lokalise.gradle.plugin.tasks.registerDownloadTranslationTask
 import com.ioki.lokalise.gradle.plugin.tasks.registerUploadTranslationTask
 import org.gradle.api.Plugin
@@ -9,9 +10,21 @@ class LokaliseGradlePlugin : Plugin<Project> {
     override fun apply(target: Project) {
         val lokaliseExtensions = target.extensions.createLokaliseExtension()
 
+        val lokaliseService = target.gradle.sharedServices.registerIfAbsent(
+            "LokaliseApi",
+            LokaliseApiBuildService::class.java
+        ) { buildServiceSpec ->
+            buildServiceSpec.parameters { lokaliseApiParams ->
+                lokaliseApiParams.apiToken.set(lokaliseExtensions.apiToken)
+                lokaliseApiParams.projectId.set(lokaliseExtensions.projectId)
+            }
+        }
+
         target.tasks.registerUploadTranslationTask(
+            lokaliseService = lokaliseService,
             lokaliseExtensions = lokaliseExtensions,
         )
+
 
         val downloadTranslationsForAll = target.tasks.register("downloadTranslationsForAll")
         lokaliseExtensions.downloadStringsConfigs.all {

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -1,27 +1,22 @@
 package com.ioki.lokalise.gradle.plugin
 
-import com.ioki.lokalise.api.Lokalise
-import com.ioki.lokalise.gradle.plugin.internal.DefaultLokaliseApi
-import com.ioki.lokalise.gradle.plugin.internal.LokaliseApi
+import com.ioki.lokalise.gradle.plugin.internal.LokaliseApiFactory
 import com.ioki.lokalise.gradle.plugin.tasks.registerDownloadTranslationTask
 import com.ioki.lokalise.gradle.plugin.tasks.registerUploadTranslationTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
 
 class LokaliseGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val lokaliseExtensions = project.extensions.createLokaliseExtension()
 
-        val lokaliseApi: Provider<LokaliseApi> = project.providers.zip(
-            lokaliseExtensions.apiToken,
-            lokaliseExtensions.projectId
-        ) { token, id ->
-            DefaultLokaliseApi(Lokalise(token), id)
-        }
+        val apiFactory = LokaliseApiFactory(
+            apiTokenProvider = lokaliseExtensions.apiToken,
+            projectIdProvider = lokaliseExtensions.projectId
+        )
 
         project.tasks.registerUploadTranslationTask(
-            lokaliseApi = lokaliseApi,
+            lokaliseApiFactory = apiFactory,
             lokaliseExtensions = lokaliseExtensions,
         )
 

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -24,7 +24,6 @@ class LokaliseGradlePlugin : Plugin<Project> {
             lokaliseExtensions = lokaliseExtensions,
         )
 
-
         val downloadTranslationsForAll = target.tasks.register("downloadTranslationsForAll")
         lokaliseExtensions.downloadStringsConfigs.all {
             val customDownloadTask = target.tasks.registerDownloadTranslationTask(

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/internal/LokaliseApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/internal/LokaliseApi.kt
@@ -8,6 +8,14 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import org.gradle.api.GradleException
+import org.gradle.api.provider.Provider
+
+class LokaliseApiFactory(
+    private val apiTokenProvider: Provider<String>,
+    private val projectIdProvider: Provider<String>,
+) {
+    fun create(): LokaliseApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
+}
 
 interface LokaliseApi {
     suspend fun uploadFiles(

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/internal/LokaliseApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/internal/LokaliseApi.kt
@@ -8,34 +8,14 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import org.gradle.api.GradleException
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildService
-import org.gradle.api.services.BuildServiceParameters
-import java.io.File
 
-internal interface LokaliseApi {
+interface LokaliseApi {
     suspend fun uploadFiles(
         fileInfos: List<FileInfo>,
         langIso: String,
         params: Map<String, Any>
     ): List<FileUpload>
     suspend fun checkProcess(fileUploads: List<FileUpload>)
-}
-
-internal abstract class LokaliseApiBuildService : BuildService<LokaliseApiParams>, LokaliseApi {
-    private val lokaliseApi = DefaultLokaliseApi(Lokalise(parameters.apiToken.get()), parameters.projectId.get())
-
-    override suspend fun uploadFiles(
-        fileInfos: List<FileInfo>,
-        langIso: String,
-        params: Map<String, Any>
-    ) = lokaliseApi.uploadFiles(
-        fileInfos,
-        langIso,
-        params,
-    )
-
-    override suspend fun checkProcess(fileUploads: List<FileUpload>) = lokaliseApi.checkProcess(fileUploads)
 }
 
 internal class DefaultLokaliseApi(
@@ -115,12 +95,7 @@ internal class DefaultLokaliseApi(
     private fun <T> List<T>.chunkedToSix(): List<List<T>> = chunked(6)
 }
 
-interface LokaliseApiParams : BuildServiceParameters {
-    val apiToken: Property<String>
-    val projectId: Property<String>
-}
-
-internal data class FileInfo(
+data class FileInfo(
     val fileName: String,
     val base64FileContent: String,
 )

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -2,9 +2,9 @@ package com.ioki.lokalise.gradle.plugin.tasks
 
 import com.ioki.lokalise.api.models.FileUpload
 import com.ioki.lokalise.gradle.plugin.LokaliseExtension
-import com.ioki.lokalise.gradle.plugin.internal.FileInfo
-import com.ioki.lokalise.gradle.plugin.internal.LokaliseApi
-import com.ioki.lokalise.gradle.plugin.internal.LokaliseApiFactory
+import com.ioki.lokalise.gradle.plugin.FileInfo
+import com.ioki.lokalise.gradle.plugin.LokaliseApi
+import com.ioki.lokalise.gradle.plugin.LokaliseApiFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -4,7 +4,6 @@ import com.ioki.lokalise.api.models.FileUpload
 import com.ioki.lokalise.gradle.plugin.LokaliseExtension
 import com.ioki.lokalise.gradle.plugin.internal.FileInfo
 import com.ioki.lokalise.gradle.plugin.internal.LokaliseApi
-import com.ioki.lokalise.gradle.plugin.internal.LokaliseApiBuildService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -19,7 +18,7 @@ import org.gradle.api.tasks.*
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
-internal abstract class UploadTranslationsTask : DefaultTask() {
+abstract class UploadTranslationsTask : DefaultTask() {
 
     @get:Internal
     abstract val lokaliseApi: Property<LokaliseApi>
@@ -74,11 +73,10 @@ internal abstract class UploadTranslationsTask : DefaultTask() {
 }
 
 internal fun TaskContainer.registerUploadTranslationTask(
-    lokaliseService: Provider<LokaliseApiBuildService>,
+    lokaliseApi: Provider<LokaliseApi>,
     lokaliseExtensions: LokaliseExtension,
 ): TaskProvider<UploadTranslationsTask> = register("uploadTranslations", UploadTranslationsTask::class.java) {
-    it.usesService(lokaliseService)
-    it.lokaliseApi.set(lokaliseService)
+    it.lokaliseApi.set(lokaliseApi)
     it.translationFilesToUpload.set(lokaliseExtensions.uploadStringsConfig.translationsFilesToUpload)
     it.params.set(lokaliseExtensions.uploadStringsConfig.params)
 }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -15,9 +15,11 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.internal.impldep.com.fasterxml.jackson.databind.annotation.JsonAppend.Prop
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -28,6 +30,10 @@ internal abstract class UploadTranslationsTask : DefaultTask() {
 
     @get:Input
     abstract val apiToken: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val pollUploadProcess: Property<Boolean>
 
     @get:Input
     abstract val translationFilesToUpload: Property<ConfigurableFileTree>
@@ -54,7 +60,7 @@ internal abstract class UploadTranslationsTask : DefaultTask() {
                     )
                 }
                 .uploadEach(lokaliseApi, params.get("lang_iso").toString(), params.remove("lang_iso"))
-                .checkProcess(lokaliseApi)
+                .run { if(pollUploadProcess.get()) checkProcess(lokaliseApi) }
         }
     }
 

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -14,7 +14,12 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskContainer
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseApiTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseApiTest.kt
@@ -6,8 +6,8 @@ import com.ioki.lokalise.api.models.FileDownload
 import com.ioki.lokalise.api.models.FileUpload
 import com.ioki.lokalise.api.models.Projects
 import com.ioki.lokalise.api.models.RetrievedProcess
-import com.ioki.lokalise.gradle.plugin.internal.DefaultLokaliseApi
-import com.ioki.lokalise.gradle.plugin.internal.FileInfo
+import com.ioki.lokalise.gradle.plugin.DefaultLokaliseApi
+import com.ioki.lokalise.gradle.plugin.FileInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.currentTime

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseApiTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseApiTest.kt
@@ -6,8 +6,8 @@ import com.ioki.lokalise.api.models.FileDownload
 import com.ioki.lokalise.api.models.FileUpload
 import com.ioki.lokalise.api.models.Projects
 import com.ioki.lokalise.api.models.RetrievedProcess
+import com.ioki.lokalise.gradle.plugin.internal.DefaultLokaliseApi
 import com.ioki.lokalise.gradle.plugin.internal.FileInfo
-import com.ioki.lokalise.gradle.plugin.internal.LokaliseApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.currentTime
@@ -22,7 +22,7 @@ class LokaliseApiTest {
     @Test
     fun `concurrency uploadFile with 1-6 files does not delay and is done after 0 millis`() = runTest {
         val lokalise = createLokalise()
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         (0..6).forEach {
             expectThat(currentTime).isEqualTo(0)
@@ -40,7 +40,7 @@ class LokaliseApiTest {
     @Test
     fun `concurrency uploadFile with 7-12 files delay once and is done after 1000 millis`() = runTest {
         val lokalise = createLokalise()
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         var expectedTime = 0L
         (7..12).forEach {
@@ -60,7 +60,7 @@ class LokaliseApiTest {
     @Test
     fun `concurrency uploadFile with 13-18 files delay twice and is done after 2000 millis`() = runTest {
         val lokalise = createLokalise()
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         var expectedTime = 0L
         (13..18).forEach {
@@ -85,7 +85,7 @@ class LokaliseApiTest {
                 Result.Success(createFileUpload())
             }
         )
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         expectThat(currentTime).isEqualTo(0L)
         lokaliseApi.uploadFiles(
@@ -107,7 +107,7 @@ class LokaliseApiTest {
                     Result.Success(createFileUpload())
                 }
             )
-            val lokaliseApi = LokaliseApi(lokalise, "projectId")
+            val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
             expectThat(currentTime).isEqualTo(0L)
             lokaliseApi.uploadFiles(
@@ -123,7 +123,7 @@ class LokaliseApiTest {
     @Test
     fun `concurrency checkProcess with 1-6 files does not delay and is done after 0 millis`() = runTest {
         val lokalise = createLokalise()
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         (0..6).forEach {
             expectThat(currentTime).isEqualTo(0)
@@ -139,7 +139,7 @@ class LokaliseApiTest {
     @Test
     fun `concurrency checkProcess with 7-12 files delay once and is done after 1000 millis`() = runTest {
         val lokalise = createLokalise()
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         var expectedTime = 0L
         (7..12).forEach {
@@ -157,7 +157,7 @@ class LokaliseApiTest {
     @Test
     fun `concurrency checkProcess with 13-18 files delay twice and is done after 2000 millis`() = runTest {
         val lokalise = createLokalise()
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         var expectedTime = 0L
         (13..18).forEach {
@@ -180,7 +180,7 @@ class LokaliseApiTest {
                 Result.Success(createRetrieveProcess(status = "finished"))
             }
         )
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         expectThat(currentTime).isEqualTo(0L)
         lokaliseApi.checkProcess(
@@ -200,7 +200,7 @@ class LokaliseApiTest {
                     Result.Success(createRetrieveProcess(status = "finished"))
                 }
             )
-            val lokaliseApi = LokaliseApi(lokalise, "projectId")
+            val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
             expectThat(currentTime).isEqualTo(0L)
             lokaliseApi.checkProcess(
@@ -221,7 +221,7 @@ class LokaliseApiTest {
                 Result.Success(createRetrieveProcess(status = status))
             }
         )
-        val lokaliseApi = LokaliseApi(lokalise, "projectId")
+        val lokaliseApi = DefaultLokaliseApi(lokalise, "projectId")
 
         expectThat(currentTime).isEqualTo(0L)
         lokaliseApi.checkProcess(

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -58,7 +58,7 @@ class UploadTranslationsTaskTest {
         buildGradle.writeText(
             """
             import com.ioki.lokalise.gradle.plugin.tasks.UploadTranslationsTask
-            import com.ioki.lokalise.gradle.plugin.internal.*
+            import com.ioki.lokalise.gradle.plugin.*
             import com.ioki.lokalise.api.models.*
                     
             plugins {

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -98,6 +98,7 @@ class UploadTranslationsTaskTest {
             .withArguments("uploadTranslations", "--configuration-cache", "--info")
             .buildAndFail()
 
+        println(result.output)
         expectThat(result.task(":uploadTranslations")?.outcome).isEqualTo(TaskOutcome.FAILED)
         expectThat(result.output).contains("Invalid `X-Api-Token`")
         expectThat(result.output.contains("Configuration cache problems found in this build")).isFalse()

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -157,7 +157,6 @@ class UploadTranslationsTaskTest {
             .withArguments("uploadTranslations", "--configuration-cache", "--info")
             .buildAndFail()
 
-        println(result.output)
         expectThat(result.task(":uploadTranslations")?.outcome).isEqualTo(TaskOutcome.FAILED)
         expectThat(result.output).contains("Invalid `X-Api-Token`")
         expectThat(result.output.contains("Configuration cache problems found in this build")).isFalse()

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -90,7 +90,7 @@ class UploadTranslationsTaskTest {
             }
             
             tasks.register<UploadTranslationsTask>("testUploadTranslations") {
-                lokaliseApi.set(fakeLokaliseApi)
+                lokaliseApiFactory.set({ fakeLokaliseApi })
                 translationFilesToUpload.set(provider {
                     fileTree(rootDir) {
                         include("build.gradle.kts")
@@ -155,6 +155,7 @@ class UploadTranslationsTaskTest {
             .withProjectDir(tempDir.toFile())
             .withPluginClasspath()
             .withArguments("uploadTranslations", "--configuration-cache", "--info")
+            .forwardOutput()
             .buildAndFail()
 
         expectThat(result.task(":uploadTranslations")?.outcome).isEqualTo(TaskOutcome.FAILED)

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -53,6 +53,65 @@ class UploadTranslationsTaskTest {
     }
 
     @Test
+    fun `UploadTranslationsTask does not call pollUploadProcess when input is set to false`() {
+        val buildGradle = Paths.get(tempDir.toString(), "build.gradle.kts")
+        buildGradle.writeText(
+            """
+            import com.ioki.lokalise.gradle.plugin.tasks.UploadTranslationsTask
+            import com.ioki.lokalise.gradle.plugin.internal.*
+            import com.ioki.lokalise.api.models.*
+                    
+            plugins {
+                id("com.ioki.lokalise")
+            }
+                
+            val fakeLokaliseApi: LokaliseApi = object : LokaliseApi {
+                override suspend fun uploadFiles(
+                    fileInfos: List<FileInfo>,
+                    langIso: String,
+                    params: Map<String, Any>
+                ): List<FileUpload> {
+                    val process = FileUpload.Process(
+                        "procId",
+                        "type",
+                        "status",
+                        "mesasge",
+                        12,
+                        "email",
+                        "at",
+                        1
+                    )
+                    return listOf(FileUpload("projId", process))
+                }
+
+                override suspend fun checkProcess(fileUploads: List<FileUpload>) {
+                    error("Was called but shouldn't be")
+                }
+            }
+            
+            tasks.register<UploadTranslationsTask>("testUploadTranslations") {
+                lokaliseApi.set(fakeLokaliseApi)
+                translationFilesToUpload.set(provider {
+                    fileTree(rootDir) {
+                        include("build.gradle.kts")
+                        include("settings.gradle")
+                    }
+                })
+                params.set(objects.mapProperty<String, Any>().convention(mapOf("lang_iso" to "en"))) 
+                pollUploadProcess.set(false)
+            }
+            """.trimIndent()
+        )
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.toFile())
+            .withPluginClasspath()
+            .withArguments("testUploadTranslations", "--info")
+            .build()
+
+        expectThat(result.task(":testUploadTranslations")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
     fun `running uploadTranslations task has been called but failed because of wrong token`() {
         val result = GradleRunner.create()
             .withProjectDir(tempDir.toFile())


### PR DESCRIPTION
closes #61 

This PR adds a new `pollUploadProcess` property to the `LokaliseExtension` as well as the `UploadTranslationsTask`.
If the property is not set it will default to `false`.

When set to `false` the upload task will skip polling the lokalise api for the process.