### PR TITLE
Add `downloadFiles` functionality to `LokaliseApi`

### DIFF
--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
@@ -11,18 +11,12 @@ import kotlinx.coroutines.delay
 import org.gradle.api.GradleException
 import org.gradle.api.provider.Provider
 
-class LokaliseUploadApiFactory(
+class LokaliseApiFactory(
     private val apiTokenProvider: Provider<String>,
     private val projectIdProvider: Provider<String>,
 ) {
-    fun create(): LokaliseUploadApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
-}
-
-class LokaliseDownloadApiFactory(
-    private val apiTokenProvider: Provider<String>,
-    private val projectIdProvider: Provider<String>,
-) {
-    fun create(): LokaliseDownloadApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
+    fun createUploadApi(): LokaliseUploadApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
+    fun createDownloadApi(): LokaliseDownloadApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
 }
 
 interface LokaliseUploadApi {

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
@@ -60,7 +60,7 @@ internal class DefaultLokaliseApi(
                     )
 
                     when (uploadResult) {
-                        is Result.Failure -> throw GradleException(uploadResult.error.message)
+                        is Result.Failure -> throw GradleException("Can't upload files\n${uploadResult.error.message}")
                         is Result.Success -> uploadResult.data
                     }
                 }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseApi.kt
@@ -41,7 +41,6 @@ interface LokaliseDownloadApi {
     ): FileDownload
 }
 
-
 internal class DefaultLokaliseApi(
     private val lokalise: Lokalise,
     private val projectId: String,

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -9,13 +9,13 @@ class LokaliseGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val lokaliseExtensions = project.extensions.createLokaliseExtension()
 
-        val apiFactory = LokaliseUploadApiFactory(
+        val apiFactory = LokaliseApiFactory(
             apiTokenProvider = lokaliseExtensions.apiToken,
             projectIdProvider = lokaliseExtensions.projectId
         )
 
         project.tasks.registerUploadTranslationTask(
-            lokaliseUploadApiFactory = apiFactory,
+            lokaliseApiFactory = apiFactory,
             lokaliseExtensions = lokaliseExtensions,
         )
 
@@ -23,10 +23,7 @@ class LokaliseGradlePlugin : Plugin<Project> {
         lokaliseExtensions.downloadStringsConfigs.all {
             val customDownloadTask = project.tasks.registerDownloadTranslationTask(
                 config = it,
-                lokaliseDownloadApiFactory = LokaliseDownloadApiFactory(
-                    apiTokenProvider = lokaliseExtensions.apiToken,
-                    projectIdProvider = lokaliseExtensions.projectId
-                ),
+                lokaliseApiFactory = apiFactory,
             )
             downloadTranslationsForAll.configure { allTask -> allTask.dependsOn(customDownloadTask) }
         }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -9,13 +9,13 @@ class LokaliseGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val lokaliseExtensions = project.extensions.createLokaliseExtension()
 
-        val apiFactory = LokaliseApiFactory(
+        val apiFactory = LokaliseUploadApiFactory(
             apiTokenProvider = lokaliseExtensions.apiToken,
             projectIdProvider = lokaliseExtensions.projectId
         )
 
         project.tasks.registerUploadTranslationTask(
-            lokaliseApiFactory = apiFactory,
+            lokaliseUploadApiFactory = apiFactory,
             lokaliseExtensions = lokaliseExtensions,
         )
 

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseGradlePlugin.kt
@@ -23,7 +23,10 @@ class LokaliseGradlePlugin : Plugin<Project> {
         lokaliseExtensions.downloadStringsConfigs.all {
             val customDownloadTask = project.tasks.registerDownloadTranslationTask(
                 config = it,
-                lokaliseExtensions = lokaliseExtensions,
+                lokaliseDownloadApiFactory = LokaliseDownloadApiFactory(
+                    apiTokenProvider = lokaliseExtensions.apiToken,
+                    projectIdProvider = lokaliseExtensions.projectId
+                ),
             )
             downloadTranslationsForAll.configure { allTask -> allTask.dependsOn(customDownloadTask) }
         }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseUploadApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseUploadApi.kt
@@ -18,6 +18,13 @@ class LokaliseUploadApiFactory(
     fun create(): LokaliseUploadApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
 }
 
+class LokaliseDownloadApiFactory(
+    private val apiTokenProvider: Provider<String>,
+    private val projectIdProvider: Provider<String>,
+) {
+    fun create(): LokaliseDownloadApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
+}
+
 interface LokaliseUploadApi {
     suspend fun uploadFiles(
         fileInfos: List<FileInfo>,

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseUploadApi.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/LokaliseUploadApi.kt
@@ -10,14 +10,14 @@ import kotlinx.coroutines.delay
 import org.gradle.api.GradleException
 import org.gradle.api.provider.Provider
 
-class LokaliseApiFactory(
+class LokaliseUploadApiFactory(
     private val apiTokenProvider: Provider<String>,
     private val projectIdProvider: Provider<String>,
 ) {
-    fun create(): LokaliseApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
+    fun create(): LokaliseUploadApi = DefaultLokaliseApi(Lokalise(apiTokenProvider.get()), projectIdProvider.get())
 }
 
-interface LokaliseApi {
+interface LokaliseUploadApi {
     suspend fun uploadFiles(
         fileInfos: List<FileInfo>,
         langIso: String,
@@ -29,7 +29,7 @@ interface LokaliseApi {
 internal class DefaultLokaliseApi(
     private val lokalise: Lokalise,
     private val projectId: String,
-) : LokaliseApi {
+) : LokaliseUploadApi {
 
     private val finishedProcessStatus = listOf("cancelled", "finished", "failed")
 

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadTranslationsTask.kt
@@ -1,12 +1,10 @@
 package com.ioki.lokalise.gradle.plugin.tasks
 
-import com.ioki.lokalise.api.Lokalise
-import com.ioki.lokalise.api.Result
 import com.ioki.lokalise.gradle.plugin.DownloadStringsConfig
-import com.ioki.lokalise.gradle.plugin.LokaliseExtension
+import com.ioki.lokalise.gradle.plugin.LokaliseDownloadApi
+import com.ioki.lokalise.gradle.plugin.LokaliseDownloadApiFactory
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.ProjectLayout
@@ -26,10 +24,7 @@ import javax.inject.Inject
 internal abstract class DownloadTranslationsTask : DefaultTask() {
 
     @get:Input
-    abstract val projectId: Property<String>
-
-    @get:Input
-    abstract val apiToken: Property<String>
+    abstract val lokaliseApiFactory: Property<() -> LokaliseDownloadApi>
 
     @get:Input
     abstract val params: MapProperty<String, Any>
@@ -45,25 +40,18 @@ internal abstract class DownloadTranslationsTask : DefaultTask() {
 
     @TaskAction
     fun f() {
-        if (!projectId.isPresent || !apiToken.isPresent)
-            throw GradleException("Please set 'lokalise.projectId' and 'lokalise.apiToken'")
-
         logger.log(LogLevel.INFO, "Execute downloading files with the following params:\n${params.get()}")
 
         val format = params.get()["format"]
         val newParams = params.get().toMutableMap().apply { remove("format") }
 
         val downloadedFile = runBlocking {
-            Lokalise(apiToken.get()).downloadFiles(
-                projectId = projectId.get(),
+            lokaliseApiFactory.get().invoke().downloadFiles(
                 format = format.toString(),
-                bodyParams = newParams,
+                params = newParams,
             )
         }
-        val bundleUrl = when (downloadedFile) {
-            is Result.Failure -> throw GradleException("Can't download files\n${downloadedFile.error.message}")
-            is Result.Success -> downloadedFile.data.bundleUrl
-        }
+        val bundleUrl = downloadedFile.bundleUrl
 
         val outputZipFile = projectLayout.buildDirectory.file("lokalise/translations.zip")
             .get()
@@ -84,13 +72,12 @@ internal abstract class DownloadTranslationsTask : DefaultTask() {
 }
 
 internal fun TaskContainer.registerDownloadTranslationTask(
+    lokaliseDownloadApiFactory: LokaliseDownloadApiFactory,
     config: DownloadStringsConfig,
-    lokaliseExtensions: LokaliseExtension,
 ): TaskProvider<DownloadTranslationsTask> = register(
     "downloadTranslationsFor${config.name.replaceFirstChar { it.titlecase() }}",
     DownloadTranslationsTask::class.java
 ) {
-    it.apiToken.set(lokaliseExtensions.apiToken)
-    it.projectId.set(lokaliseExtensions.projectId)
+    it.lokaliseApiFactory.set(lokaliseDownloadApiFactory::create)
     it.params.set(config.params)
 }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadTranslationsTask.kt
@@ -1,8 +1,8 @@
 package com.ioki.lokalise.gradle.plugin.tasks
 
 import com.ioki.lokalise.gradle.plugin.DownloadStringsConfig
+import com.ioki.lokalise.gradle.plugin.LokaliseApiFactory
 import com.ioki.lokalise.gradle.plugin.LokaliseDownloadApi
-import com.ioki.lokalise.gradle.plugin.LokaliseDownloadApiFactory
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ArchiveOperations
@@ -72,12 +72,12 @@ internal abstract class DownloadTranslationsTask : DefaultTask() {
 }
 
 internal fun TaskContainer.registerDownloadTranslationTask(
-    lokaliseDownloadApiFactory: LokaliseDownloadApiFactory,
+    lokaliseApiFactory: LokaliseApiFactory,
     config: DownloadStringsConfig,
 ): TaskProvider<DownloadTranslationsTask> = register(
     "downloadTranslationsFor${config.name.replaceFirstChar { it.titlecase() }}",
     DownloadTranslationsTask::class.java
 ) {
-    it.lokaliseApiFactory.set(lokaliseDownloadApiFactory::create)
+    it.lokaliseApiFactory.set(lokaliseApiFactory::createDownloadApi)
     it.params.set(config.params)
 }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -1,10 +1,7 @@
 package com.ioki.lokalise.gradle.plugin.tasks
 
 import com.ioki.lokalise.api.models.FileUpload
-import com.ioki.lokalise.gradle.plugin.LokaliseExtension
-import com.ioki.lokalise.gradle.plugin.FileInfo
-import com.ioki.lokalise.gradle.plugin.LokaliseUploadApi
-import com.ioki.lokalise.gradle.plugin.LokaliseUploadApiFactory
+import com.ioki.lokalise.gradle.plugin.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -78,10 +75,10 @@ abstract class UploadTranslationsTask : DefaultTask() {
 }
 
 internal fun TaskContainer.registerUploadTranslationTask(
-    lokaliseUploadApiFactory: LokaliseUploadApiFactory,
+    lokaliseApiFactory: LokaliseApiFactory,
     lokaliseExtensions: LokaliseExtension,
 ): TaskProvider<UploadTranslationsTask> = register("uploadTranslations", UploadTranslationsTask::class.java) {
-    it.lokaliseApiFactory.set(lokaliseUploadApiFactory::create)
+    it.lokaliseApiFactory.set(lokaliseApiFactory::createUploadApi)
     it.translationFilesToUpload.set(lokaliseExtensions.uploadStringsConfig.translationsFilesToUpload)
     it.params.set(lokaliseExtensions.uploadStringsConfig.params)
 }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -1,7 +1,10 @@
 package com.ioki.lokalise.gradle.plugin.tasks
 
 import com.ioki.lokalise.api.models.FileUpload
-import com.ioki.lokalise.gradle.plugin.*
+import com.ioki.lokalise.gradle.plugin.FileInfo
+import com.ioki.lokalise.gradle.plugin.LokaliseApiFactory
+import com.ioki.lokalise.gradle.plugin.LokaliseExtension
+import com.ioki.lokalise.gradle.plugin.LokaliseUploadApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -3,8 +3,8 @@ package com.ioki.lokalise.gradle.plugin.tasks
 import com.ioki.lokalise.api.models.FileUpload
 import com.ioki.lokalise.gradle.plugin.LokaliseExtension
 import com.ioki.lokalise.gradle.plugin.FileInfo
-import com.ioki.lokalise.gradle.plugin.LokaliseApi
-import com.ioki.lokalise.gradle.plugin.LokaliseApiFactory
+import com.ioki.lokalise.gradle.plugin.LokaliseUploadApi
+import com.ioki.lokalise.gradle.plugin.LokaliseUploadApiFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -25,7 +25,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 abstract class UploadTranslationsTask : DefaultTask() {
 
     @get:Input
-    abstract val lokaliseApiFactory: Property<() -> LokaliseApi>
+    abstract val lokaliseApiFactory: Property<() -> LokaliseUploadApi>
 
     @get:Input
     @get:Optional
@@ -65,23 +65,23 @@ abstract class UploadTranslationsTask : DefaultTask() {
     }
 
     private suspend fun List<FileInfo>.uploadEach(
-        lokaliseApi: LokaliseApi,
+        lokaliseApi: LokaliseUploadApi,
         langIso: String,
         params: Map<String, Any>,
     ): List<FileUpload> = withContext(Dispatchers.IO) {
         lokaliseApi.uploadFiles(this@uploadEach, langIso, params)
     }
 
-    private suspend fun List<FileUpload>.checkProcess(lokaliseApi: LokaliseApi) = withContext(Dispatchers.IO) {
+    private suspend fun List<FileUpload>.checkProcess(lokaliseApi: LokaliseUploadApi) = withContext(Dispatchers.IO) {
         lokaliseApi.checkProcess(this@checkProcess)
     }
 }
 
 internal fun TaskContainer.registerUploadTranslationTask(
-    lokaliseApiFactory: LokaliseApiFactory,
+    lokaliseUploadApiFactory: LokaliseUploadApiFactory,
     lokaliseExtensions: LokaliseExtension,
 ): TaskProvider<UploadTranslationsTask> = register("uploadTranslations", UploadTranslationsTask::class.java) {
-    it.lokaliseApiFactory.set(lokaliseApiFactory::create)
+    it.lokaliseApiFactory.set(lokaliseUploadApiFactory::create)
     it.translationFilesToUpload.set(lokaliseExtensions.uploadStringsConfig.translationsFilesToUpload)
     it.params.set(lokaliseExtensions.uploadStringsConfig.params)
 }

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseUploadApiTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/LokaliseUploadApiTest.kt
@@ -17,7 +17,7 @@ import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class LokaliseApiTest {
+class LokaliseUploadApiTest {
 
     @Test
     fun `concurrency uploadFile with 1-6 files does not delay and is done after 0 millis`() = runTest {

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -65,7 +65,7 @@ class UploadTranslationsTaskTest {
                 id("com.ioki.lokalise")
             }
                 
-            val fakeLokaliseApi: LokaliseApi = object : LokaliseApi {
+            val fakeLokaliseApi: LokaliseUploadApi = object : LokaliseUploadApi {
                 override suspend fun uploadFiles(
                     fileInfos: List<FileInfo>,
                     langIso: String,


### PR DESCRIPTION
closes #69 

As discussed in the issue, I went ahead and created a second interface for the `downloadFiles` function which will be implemented by the `DefaultLokaliseApi`.

I am unsure of the now 2 factory classes. Maybe there is a way to combine them into 1?

`DownloadTranslationsTask` now uses the new `LokaliseDownloadApi` and gets it as an input the same way it was done for the `UploadTranslationsTask`.