### PR TITLE
Fix for optional upload poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ If you run the latter, it will only download the translated strings for spanish.
 
 There is also an `downloadTranslationsForAll` task that aggregates all created tasks to run all of them together.
 
+#### Polling configuration (optional, default `true`)
+
+By default, the plugin will poll the Lokalise API until the upload is finished.
+This is helpful to catch errors with the uploaded files.
+
+However, if you want to disable this behaviour you can set the `pollUploadProcess` property to `false`:
+```kotlin
+lokalise {
+  pollUploadProcess.set(false)
+}
+```
+
 # Release
 
 ## Snapshot release

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -83,6 +83,7 @@ internal fun TaskContainer.registerUploadTranslationTask(
 ): TaskProvider<UploadTranslationsTask> = register("uploadTranslations", UploadTranslationsTask::class.java) {
     it.lokaliseApiFactory.set(lokaliseApiFactory::createUploadApi)
     it.translationFilesToUpload.set(lokaliseExtensions.uploadStringsConfig.translationsFilesToUpload)
+    it.pollUploadProcess.set(lokaliseExtensions.pollUploadProcess)
     it.params.set(lokaliseExtensions.uploadStringsConfig.params)
 }
 


### PR DESCRIPTION
The [first commit](https://github.com/ioki-mobility/LokaliseGradlePlugin/commit/f35438c7caea7e5d50479ad3ddf26ec03efdeeff) fixes the plugin itself 😅 
We forget to forward the extension poll property to the UploadTask property 🙈 

The second commit documents the poll option.
fixes #70 