### PR TITLE
Give each tasks a group and description

### DIFF
--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/CheckEverythingTranslatedTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/CheckEverythingTranslatedTask.kt
@@ -35,4 +35,6 @@ internal fun TaskContainer.registerCheckEverythingTranslatedTask(
 ) {
     it.lokaliseApiFactory.set(lokaliseApiFactory::createProjectApi)
     it.onlyIf { config.checkTranslationProcess.getOrElse(false) }
+    it.group = "Lokalise"
+    it.description = "Check if all keys are translated for ${config.name}"
 }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadTranslationsTask.kt
@@ -80,4 +80,6 @@ internal fun TaskContainer.registerDownloadTranslationTask(
 ) {
     it.lokaliseApiFactory.set(lokaliseApiFactory::createDownloadApi)
     it.params.set(config.params)
+    it.group = "Lokalise"
+    it.description = "Download translations from Lokalise for ${config.name}"
 }

--- a/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
+++ b/src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt
@@ -85,6 +85,8 @@ internal fun TaskContainer.registerUploadTranslationTask(
     it.translationFilesToUpload.set(lokaliseExtensions.uploadStringsConfig.translationsFilesToUpload)
     it.pollUploadProcess.set(lokaliseExtensions.pollUploadProcess)
     it.params.set(lokaliseExtensions.uploadStringsConfig.params)
+    it.group = "Lokalise"
+    it.description = "Upload translations to Lokalise"
 }
 
 private fun MapProperty<String, Any>.get(key: String): Any =

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/CheckEverythingTranslatedTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/CheckEverythingTranslatedTaskTest.kt
@@ -44,6 +44,19 @@ class CheckEverythingTranslatedTaskTest {
     }
 
     @Test
+    fun `tasks has group and description`() {
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.toFile())
+            .withPluginClasspath()
+            .withArguments("tasks")
+            .build()
+
+        expectThat(result.output).contains("Lokalise")
+        expectThat(result.output).contains("Check if all keys are translated for library")
+        expectThat(result.output).contains("Check if all keys are translated for flavor")
+    }
+
+    @Test
     fun `running downloadTranslationsForLibrary will first run checkEverythingIsTranslatedForLibrary`() {
         val result = GradleRunner.create()
             .withProjectDir(tempDir.toFile())

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadAllTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadAllTranslationsTaskTest.kt
@@ -48,6 +48,19 @@ class DownloadAllTranslationsTaskTest {
     }
 
     @Test
+    fun `tasks has group and description`() {
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.toFile())
+            .withPluginClasspath()
+            .withArguments("tasks")
+            .build()
+
+        expectThat(result.output).contains("Lokalise")
+        expectThat(result.output).contains("Download translations from Lokalise for main")
+        expectThat(result.output).contains("Download translations from Lokalise for spanishOnly")
+    }
+
+    @Test
     fun `running downloadTranslationsForAll task will execute ForMain and ForSpanishOnly tasks too`() {
         val result = GradleRunner.create()
             .withProjectDir(tempDir.toFile())

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadTranslationsTaskTest.kt
@@ -54,6 +54,18 @@ class DownloadTranslationsTaskTest {
     }
 
     @Test
+    fun `tasks has group and description`() {
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.toFile())
+            .withPluginClasspath()
+            .withArguments("tasks")
+            .build()
+
+        expectThat(result.output).contains("Lokalise")
+        expectThat(result.output).contains("Download translations from Lokalise for library")
+    }
+
+    @Test
     fun `running downloadTranslationsForLibrary task has been called but failed because of wrong token`() {
         val result = GradleRunner.create()
             .withProjectDir(tempDir.toFile())

--- a/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
+++ b/src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt
@@ -53,6 +53,18 @@ class UploadTranslationsTaskTest {
     }
 
     @Test
+    fun `tasks has group and description`() {
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.toFile())
+            .withPluginClasspath()
+            .withArguments("tasks")
+            .build()
+
+        expectThat(result.output).contains("Lokalise")
+        expectThat(result.output).contains("Upload translations to Lokalise")
+    }
+
+    @Test
     fun `UploadTranslationsTask does not call pollUploadProcess when input is set to false`() {
         val buildGradle = Paths.get(tempDir.toString(), "build.gradle.kts")
         buildGradle.writeText(


### PR DESCRIPTION
fixes #28 

When running `gradlew tasks` the output look like that:
![Screenshot 2025-01-10 at 4 00 44 PM](https://github.com/user-attachments/assets/beace01d-7e0c-4ea8-ac2d-fe72cec163c2)


### AI summary:
This pull request enhances the Gradle plugin tasks by adding group and description properties to improve task organization and clarity. Additionally, it introduces unit tests to verify these properties.

Enhancements to Gradle plugin tasks:

* [`src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/CheckEverythingTranslatedTask.kt`](diffhunk://#diff-63c7219729ab8baf642c282c944ef951de7dae70db1aef3f1b49c829a363e90dR38-R39): Added `group` and `description` properties to the `registerCheckEverythingTranslatedTask` function.
* [`src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/DownloadTranslationsTask.kt`](diffhunk://#diff-14a085ae7404d6af6ea8d90381d738dffe861a3db3cf88f7f2c732232e2b39c0R83-R84): Added `group` and `description` properties to the `registerDownloadTranslationTask` function.
* [`src/main/kotlin/com/ioki/lokalise/gradle/plugin/tasks/UploadTranslationsTask.kt`](diffhunk://#diff-942b0fdf2ecf58b7ee937755b4ff2cc19a29d026af3e9bfef1ee8164c19b6fb6R88-R89): Added `group` and `description` properties to the `registerUploadTranslationTask` function.

Unit tests for task properties:

* [`src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/CheckEverythingTranslatedTaskTest.kt`](diffhunk://#diff-4c1283b4dea662949f3f1278dcdcda2c04610e5ba5abf0d89a1b23b776fba8fbR46-R58): Added a test to verify the `group` and `description` properties for `CheckEverythingTranslatedTask`.
* [`src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadAllTranslationsTaskTest.kt`](diffhunk://#diff-7964b21d3b16755a1a8e65939fae1abed405db076cce42865fb3094340d366caR50-R62): Added a test to verify the `group` and `description` properties for `DownloadAllTranslationsTask`.
* [`src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/DownloadTranslationsTaskTest.kt`](diffhunk://#diff-0dbdab3431ff32092d45001c29827eeb36a91db4efc34bec743dd753aacbf2c4R56-R67): Added a test to verify the `group` and `description` properties for `DownloadTranslationsTask`.
* [`src/test/kotlin/com/ioki/lokalise/gradle/plugin/unit/UploadTranslationsTaskTest.kt`](diffhunk://#diff-3a864edee427d6b4802104114eaadc28bf7dcdba268b13315ea80ad7f0a6f378R55-R66): Added a test to verify the `group` and `description` properties for `UploadTranslationsTask`.

